### PR TITLE
Fix JSON formatting in the patreons file

### DIFF
--- a/string-core/patreons.json
+++ b/string-core/patreons.json
@@ -5,7 +5,7 @@
   "Tier 4": [
   ],
   "Tier 3": [
-    "Ahri~",
+    "Ahri~"
   ],
   "Tier 2": [
     "Sayl_",


### PR DESCRIPTION
This PR fixes a minor issue in the JSON formatting of the patreons file. Specifically, I removed an unnecessary comma after the "Ahri~" (last and only) entry in the "Tier 3" list. This comma was causing the GitHub Action to fail so the changes were not detected by clients visiting the world (the baked file is fetched). The JSON is now properly formatted and does not cause any errors.

PS: Pay attention to commas and/or consider adding auto corrections in the Python GitHub action (maybe with regex (?))